### PR TITLE
Add blog of Flycheck maintainer

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -651,6 +651,9 @@ name = Eric James Michael Ritz
 [http://blog.binchen.org/?feed=rss2&tag=emacs]
 name = Chen Bin (redguardtoo)
 
+[http://www.lunaryorn.com/tags/emacs.atom]
+name = Sebastian Wiesner
+
 # TODO: look to:
 # - http://snarfed.org/
 # - http://lars.ingebrigtsen.no/


### PR DESCRIPTION
I'm the maintainer of [Flycheck](http://flycheck.readthedocs.org/en/latest/), and this PR adds the Emacs feed of blog to Panel Emacsen. 
