### PR TITLE
Add Endless Parentheses blog

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -651,6 +651,9 @@ name = Eric James Michael Ritz
 [http://blog.binchen.org/?feed=rss2&tag=emacs]
 name = Chen Bin (redguardtoo)
 
+[http://endlessparentheses.com/atom-planet.xml]
+name = Endless Parentheses
+
 # TODO: look to:
 # - http://snarfed.org/
 # - http://lars.ingebrigtsen.no/


### PR DESCRIPTION
http://endlessparentheses.com/ is a blog exclusively about emacs. Should be a good fit for planet.emacsen.org.
