### PR TITLE
Update blog name to "(or emacs"

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -680,7 +680,7 @@ name = Cameron Desautels
 name = Michael Fogleman
 
 [http://oremacs.com/atom.xml]
-name = Oleh Krehel
+name = (or emacs
 
 [http://www.russet.org.uk/blog/category/all/professional/tech/emacs/feed]
 name=Phillip Lord


### PR DESCRIPTION
I think the blog name is more memorable than my name.