### PR TITLE
Add kbd, cursor and region to the css

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -525,3 +525,35 @@ code.elisp samp      { font-weight: normal; }
   float: right;
   margin: 0.5em;
 }
+
+region {
+    color: #ffffff;
+    background-color: #f9b593;
+}
+
+kbd {
+    padding:0.1em 0.6em;
+    border:1px solid #ccc;
+    font-size:13px;
+    font-weight:bold;
+    font-family:monospace;
+    background-color:#f3d3d3;
+    color:#333;
+    -moz-box-shadow:0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+    -webkit-box-shadow:0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+    box-shadow:0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+    -moz-border-radius:3px;
+    -webkit-border-radius:3px;
+    border-radius:3px;
+    display:inline-block;
+    margin:0 0.1em;
+    text-shadow:0 1px 0 #fff;
+    line-height:1.4;
+    white-space:nowrap;
+}
+
+cursor {
+    color: #fff;
+    background-color: #000;
+    overflow: hidden;
+}


### PR DESCRIPTION
* html/style.css: amend.

My blog is using `kbd`, `cursor` and `region` tags extensively.
Other blogs may use this stuff as well, at least `kbd`, which is
part of Github and Stack Exchange-flavored markdown.
