### PR TITLE
Updated feed for pragmatic emacs

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -691,7 +691,7 @@ name=Phillip Lord
 [http://whatthefuck.computer/rss.xml]
 name=Ryan Rix
 
-[https://pragmaticemacs.wordpress.com/feed/]
+[http://pragmaticemacs.com/feed/]
 name = Pragmatic Emacs
 
 # TODO: look to:


### PR DESCRIPTION
I have moved the blog from wordpress.com to its own domain, so have updated the feed URL