### PR TITLE
Reverted a URL fix

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -626,7 +626,7 @@ name = Yves Senn
 [http://whattheemacsd.com/atom.xml]
 name = What the .emacs.d!?
 
-[https://www.wisdomandwonder.com/tag/emacs/feed]
+[http://www.wisdomandwonder.com/tag/emacs/feed]
 name = Grant Rettke
 
 [http://jr0cket.co.uk/tags/emacs/]


### PR DESCRIPTION
A month or two ago I updated my WordPress to redirect everything to HTTPS.

Then I noticed that Planet Emacsen wasn't syndicating my Emacs specific posts via

http://www.wisdomandwonder.com/tag/emacs/feed

@hober looked into it and corrected the url from http to https. 

Still, the posts weren't pulled in.

Suspect that Planet Venus isn't happy with my https url so I am switching it back to see what happens.