### PR TITLE
Update Jonas Bernoulli's feed

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -344,7 +344,7 @@ name = Thomas Kappler
 [http://manandbytes.wordpress.com/tag/emacs/feed/]
 name = Mykola Nikishov
 
-[https://emacsair.me/feed.xml]
+[http://emacsair.me.s3-website.eu-central-1.amazonaws.com/feed.xml]
 name = Jonas Bernoulli
 
 [http://blog.peopleareducks.com/category/emacs/feed/]


### PR DESCRIPTION
In #67 I changed the url for my feed from http to https. I did so because http is now being
redirected to https, and the planet software doesn't seem to follow that redirection. Since
then I have made another post and it did not show up on the planet. Which was a good
thing in this particular case because it was an accidental push of a draft. But it appears
that the planet software doesn't support https at all, and so I am changing to yet another
url. It is accessible using http but was only intended for internal purposes.