### PR TITLE
Use a different url to get my blogs feed

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -349,8 +349,10 @@ name = Thomas Kappler
 [https://manandbytes.wordpress.com/tag/emacs/feed/]
 name = Mykola Nikishov
 
-# [https://emacsair.me/feed.xml]
-# name = Jonas Bernoulli
+# Actual public url is https://emacsair.me/feed.xml,
+# but it appears planet venus has issues with https.
+[http://emacsair.me.s3-website.eu-central-1.amazonaws.com/feed.xml]
+name = Jonas Bernoulli
 
 # [http://blog.peopleareducks.com/category/emacs/feed/]
 [https://blog.lnx.cx/category/emacs/feed/]
@@ -713,9 +715,6 @@ name = Yaniv Gilad
 
 # [http://codingquark.com/category/emacs/feed/]
 # name = codingquark
-
-[https://emacsair.me/feed.xml]
-name = emacsair
 
 [http://emacsninja.com/feed.atom]
 name = emacsninja


### PR DESCRIPTION
Actual public url is https://emacsair.me/feed.xml but it appears planet venus has issues with https.