### PR TITLE
Fix emacsninja feed

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -717,7 +717,7 @@ name = Yaniv Gilad
 [https://emacsair.me/feed.xml]
 name = emacsair
 
-[http://emacsninja.com/feed.atom]
+[http://emacsninja.com/emacs.atom]
 name = emacsninja
 
 [http://emacshorrors.com/feed.atom]


### PR DESCRIPTION
I've found out while googling my name that apparently both of my blogs, both emacshorrors.com and emacsninja.com are on planet.emacsen.org.  This is OK for emacshorrors.com as it's Emacs-only, however emacsninja.com isn't.  I've added an Emacs-only feed for it today and would like to replace the current feed URL with it.