### PR TITLE
Add: Modern Emacs at ekaschalk.github.io

### DIFF
--- a/en.ini
+++ b/en.ini
@@ -746,6 +746,9 @@ name = Martin R. Albrecht
 [http://emacs.cafe/feed.xml]
 name = Emacs café
 
+[https://ekaschalk.github.io/categories/emacs/index.xml]
+name = Modern Emacs
+
 # TODO: look to:
 # - http://snarfed.org/
 # - http://lars.ingebrigtsen.no/


### PR DESCRIPTION
Add emacs section of my blog "Modern Emacs" at https://ekaschalk.github.io/